### PR TITLE
Fixed UPM header

### DIFF
--- a/rgb_lcd_demo/rgb_lcd_demo.cpp
+++ b/rgb_lcd_demo/rgb_lcd_demo.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <string>
-#include "upm/jhd1313m1.h"
+#include "upm/jhd1313m1.hpp"
 
 #define I2C_BUS  0
 #define RGB_WHT 0xff,0xff,0xff


### PR DESCRIPTION
Headers use .hpp not .h

Signed-off-by: Mark Charlebois <charlebm@gmail.com>